### PR TITLE
초대장 정보를 api를 통해 받아오는 요청로직 작성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12560,6 +12560,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "moment": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "immutable": "4.0.0-rc.12",
     "lodash": "4.17.19",
     "lru-cache": "6.0.0",
+    "moment": "2.27.0",
     "node-plop": "0.25.0",
     "node-sass": "4.14.1",
     "platform": "1.3.6",
@@ -126,5 +127,6 @@
         "statements": 90
       }
     }
-  }
+  },
+  "proxy": "http://ec2-13-124-3-1.ap-northeast-2.compute.amazonaws.com:8080"
 }

--- a/src/api/invitationAPI.ts
+++ b/src/api/invitationAPI.ts
@@ -11,8 +11,8 @@ export interface getInvitationResponseType {
   invitationAddressName: string
   invitationRoadAddress: string
   invitationPlaceName: string
-  invitationX: number
-  invitationY: number
+  x: number
+  y: number
   images: string[]
 }
 

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -21,4 +21,4 @@ function Comment({ comment }: CommentProps) {
   )
 }
 
-export default Comment
+export default React.memo(Comment)

--- a/src/components/Invitation/Invitation.module.scss
+++ b/src/components/Invitation/Invitation.module.scss
@@ -69,11 +69,12 @@
             }
           }
           .infos {
-            padding: 0 16px;
+            width: 100%;
             display: flex;
             justify-content: space-between;
 
             .info {
+              width: 33.33%;
               display: flex;
               flex-direction: column;
               align-items: center;

--- a/src/components/Invitation/Invitation.tsx
+++ b/src/components/Invitation/Invitation.tsx
@@ -6,19 +6,19 @@ import classNames from 'classnames/bind'
 import Label from 'elements/Label'
 import KakaoMap from 'elements/KakaoMap'
 import SVGIcon from 'elements/SVGIcon'
+import InvitationModel from 'models/Invitation'
+import { getDate, getTime } from 'utils/dateUtils'
 import styled from './Invitation.module.scss'
 
 interface InvitationProps {
-  title: string
-  description: string
-  date: string
-  time: string
-  simpleLocation: string
+  invitation: InvitationModel
 }
 
 const cx = classNames.bind(styled)
 
-function Invitation({ title, description, date, time, simpleLocation }: InvitationProps) {
+function Invitation({ invitation }: InvitationProps) {
+  const simplePlaceName = invitation.placeName.split(' ')[0]
+
   return (
     <div className={cx('template-wrapper')}>
       <header>
@@ -28,8 +28,8 @@ function Invitation({ title, description, date, time, simpleLocation }: Invitati
       </header>
       <section>
         <article className={cx('template-description')}>
-          <p className={cx('title')}>{title}</p>
-          <p className={cx('description')}>{description}</p>
+          <p className={cx('title')}>{invitation.title}</p>
+          <p className={cx('description')}>{invitation.contents}</p>
         </article>
         <article className={cx('template-content')}>
           <div className={cx('content-section')}>
@@ -43,21 +43,21 @@ function Invitation({ title, description, date, time, simpleLocation }: Invitati
                   <SVGIcon name="calendar" />
                   <p>날짜</p>
                 </div>
-                <div className={cx('info-content')}>{date}</div>
+                <div className={cx('info-content')}>{getDate(invitation.time)}</div>
               </div>
               <div className={cx('info', 'time-wrapper')}>
                 <div className={cx('info-title')}>
                   <SVGIcon name="time" />
                   <p>시간</p>
                 </div>
-                <div className={cx('info-content')}>{time}</div>
+                <div className={cx('info-content')}>{getTime(invitation.time)}</div>
               </div>
               <div className={cx('info', 'location-wrapper')}>
                 <div className={cx('info-title')}>
                   <SVGIcon name="location" />
                   <p>장소</p>
                 </div>
-                <div className={cx('info-content')}>{simpleLocation}</div>
+                <div className={cx('info-content')}>{simplePlaceName}</div>
               </div>
             </div>
           </div>
@@ -72,8 +72,9 @@ function Invitation({ title, description, date, time, simpleLocation }: Invitati
             </div>
             <div className={cx('info-content')}>
               <KakaoMap
-                generalAddress="잠실1동 코워킹 스페이스"
-                detailAddress="서울특별시 송파구 잠실1동-5 마천로 328 오금현대아파트 43동"
+                placeName={invitation.placeName}
+                addressName={invitation.addressName}
+                roadAddress={invitation.roadAddress}
                 latitude={33.450701}
                 longitude={126.570667}
               />

--- a/src/components/Invitation/Invitation.tsx
+++ b/src/components/Invitation/Invitation.tsx
@@ -17,7 +17,8 @@ interface InvitationProps {
 const cx = classNames.bind(styled)
 
 function Invitation({ invitation }: InvitationProps) {
-  const simplePlaceName = invitation.placeName.split(' ')[0]
+  const simplePlaceName = invitation.kakaoMap.placeName.split(' ')[0]
+  const { kakaoMap } = invitation
 
   return (
     <div className={cx('template-wrapper')}>
@@ -71,13 +72,7 @@ function Invitation({ invitation }: InvitationProps) {
               <p>주소</p>
             </div>
             <div className={cx('info-content')}>
-              <KakaoMap
-                placeName={invitation.placeName}
-                addressName={invitation.addressName}
-                roadAddress={invitation.roadAddress}
-                latitude={33.450701}
-                longitude={126.570667}
-              />
+              <KakaoMap kakaoMap={kakaoMap} />
             </div>
           </div>
         </article>

--- a/src/containers/InvitationContainer.tsx
+++ b/src/containers/InvitationContainer.tsx
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 /* Internal dependencies */
@@ -15,15 +15,11 @@ function InvitationContainer({ templateId }: InvitationContainerProps) {
   const dispatch = useDispatch()
   const invitation = useSelector(invitationSelector.getInvitation)
 
-  return (
-    <Invitation
-      title="모각코하러 모이자!"
-      description="나의모임에 초대된 감자 친구들! 우리는 엄청난 서비스를 만들 수 있을꺼야!"
-      date="11월 27일"
-      time="오후 12시"
-      simpleLocation="잠실 1동"
-    />
-  )
+  useEffect(() => {
+    dispatch(invitationAction.getInvitation({ templateId }))
+  }, [templateId, dispatch])
+
+  return <Invitation invitation={invitation} />
 }
 
 export default InvitationContainer

--- a/src/elements/KakaoMap/KakaoMap.styled.ts
+++ b/src/elements/KakaoMap/KakaoMap.styled.ts
@@ -12,18 +12,31 @@ export const AddressWrapper = styled.div`
   padding: 8px 16px 0;
 `
 
-export const GeneralAddress = styled.p`
-  font-size: 16px;
+export const PlaceName = styled.p`
+  font-size: 14px;
 `
 
-export const DetailAddress = styled.p`
+export const AddressName = styled.p`
   margin-top: 4px;
   font-size: 12px;
   color: #a9a9a9;
 `
 
+export const RoadAddress = styled.p`
+  margin-top: 4px;
+  font-size: 12px;
+  color: #a9a9a9;
+`
+
+export const AddressTag = styled.span`
+  padding: 0 3px;
+  margin-right: 4px;
+  border: 1px solid #a9a9a9;
+  border-radius: 2px;
+`
+
 export const MapContainer = styled.div`
   width: 100%;
   height: 86px;
-  margin-top: 4px;
+  margin-top: 12px;
 `

--- a/src/elements/KakaoMap/KakaoMap.tsx
+++ b/src/elements/KakaoMap/KakaoMap.tsx
@@ -6,13 +6,14 @@ import KakaoMapService from 'services/KakaoMapService'
 import * as Styled from './KakaoMap.styled'
 
 interface KakaoMapProps {
-  generalAddress: string
-  detailAddress: string
+  placeName: string
+  addressName: string
+  roadAddress: string
   latitude: number
   longitude: number
 }
 
-function KakaoMap({ generalAddress, detailAddress, latitude, longitude }: KakaoMapProps) {
+function KakaoMap({ placeName, addressName, roadAddress, latitude, longitude }: KakaoMapProps) {
   const mapContainer = useRef(null)
 
   useEffect(() => {
@@ -23,8 +24,12 @@ function KakaoMap({ generalAddress, detailAddress, latitude, longitude }: KakaoM
   return (
     <Styled.MapWrapper>
       <Styled.AddressWrapper>
-        <Styled.GeneralAddress>{generalAddress}</Styled.GeneralAddress>
-        <Styled.DetailAddress>{detailAddress}</Styled.DetailAddress>
+        <Styled.PlaceName>{placeName}</Styled.PlaceName>
+        <Styled.AddressName>{addressName}</Styled.AddressName>
+        <Styled.RoadAddress>
+          <Styled.AddressTag>도로명</Styled.AddressTag>
+          {roadAddress || '서울특별시 송파구 잠실1동-5 마천로 328 오금현대아파트 43동'}
+        </Styled.RoadAddress>
       </Styled.AddressWrapper>
       <Styled.MapContainer ref={mapContainer} />
     </Styled.MapWrapper>

--- a/src/elements/KakaoMap/KakaoMap.tsx
+++ b/src/elements/KakaoMap/KakaoMap.tsx
@@ -2,33 +2,30 @@
 import React, { useRef, useEffect } from 'react'
 
 /* Internal dependencies */
+import KakakoMap from 'models/KakaoMap'
 import KakaoMapService from 'services/KakaoMapService'
 import * as Styled from './KakaoMap.styled'
 
 interface KakaoMapProps {
-  placeName: string
-  addressName: string
-  roadAddress: string
-  latitude: number
-  longitude: number
+  kakaoMap: KakakoMap
 }
 
-function KakaoMap({ placeName, addressName, roadAddress, latitude, longitude }: KakaoMapProps) {
+function KakaoMap({ kakaoMap }: KakaoMapProps) {
   const mapContainer = useRef(null)
 
   useEffect(() => {
-    const mapService = new KakaoMapService(mapContainer.current, latitude, longitude)
+    const mapService = new KakaoMapService(mapContainer.current, 33.450701, 126.570667)
     mapService.loadMap()
-  }, [latitude, longitude])
+  }, [kakaoMap])
 
   return (
     <Styled.MapWrapper>
       <Styled.AddressWrapper>
-        <Styled.PlaceName>{placeName}</Styled.PlaceName>
-        <Styled.AddressName>{addressName}</Styled.AddressName>
+        <Styled.PlaceName>{kakaoMap.placeName}</Styled.PlaceName>
+        <Styled.AddressName>{kakaoMap.addressName}</Styled.AddressName>
         <Styled.RoadAddress>
           <Styled.AddressTag>도로명</Styled.AddressTag>
-          {roadAddress || '서울특별시 송파구 잠실1동-5 마천로 328 오금현대아파트 43동'}
+          {kakaoMap.roadAddress || '서울특별시 송파구 잠실1동-5 마천로 328 오금현대아파트 43동'}
         </Styled.RoadAddress>
       </Styled.AddressWrapper>
       <Styled.MapContainer ref={mapContainer} />

--- a/src/models/Invitation.ts
+++ b/src/models/Invitation.ts
@@ -1,15 +1,14 @@
 /* External dependencies */
 import Immutable from 'immutable'
 
+/* Internal dependencies */
+import KakaoMap from 'models/KakaoMap'
+
 export interface InvitationAttr {
   title: string
   contents: string
   time: Date
-  addressName: string
-  roadAddress: string
-  placeName: string
-  latitude: number
-  longitude: number
+  kakaoMap: KakaoMap
   images: string[]
 }
 
@@ -17,11 +16,13 @@ const InvitationRecord = Immutable.Record<InvitationAttr>({
   title: '',
   contents: '',
   time: new Date(),
-  addressName: '',
-  roadAddress: '',
-  placeName: '',
-  latitude: 0,
-  longitude: 0,
+  kakaoMap: new KakaoMap({
+    addressName: '',
+    roadAddress: '',
+    placeName: '',
+    latitude: 0,
+    longitude: 0,
+  }),
   images: [],
 })
 

--- a/src/models/Invitation.ts
+++ b/src/models/Invitation.ts
@@ -16,13 +16,7 @@ const InvitationRecord = Immutable.Record<InvitationAttr>({
   title: '',
   contents: '',
   time: new Date(),
-  kakaoMap: new KakaoMap({
-    addressName: '',
-    roadAddress: '',
-    placeName: '',
-    latitude: 0,
-    longitude: 0,
-  }),
+  kakaoMap: new KakaoMap(),
   images: [],
 })
 

--- a/src/models/KakaoMap.ts
+++ b/src/models/KakaoMap.ts
@@ -1,0 +1,22 @@
+/* External dependencies */
+import Immutable from 'immutable'
+
+export interface KakaoMapAttr {
+  addressName: string
+  roadAddress: string
+  placeName: string
+  latitude: number
+  longitude: number
+}
+
+const KakaoMapRecord = Immutable.Record<KakaoMapAttr>({
+  addressName: '',
+  roadAddress: '',
+  placeName: '',
+  latitude: 0,
+  longitude: 0,
+})
+
+class KakaoMap extends KakaoMapRecord {}
+
+export default KakaoMap

--- a/src/redux/reducers/invitationReducer.ts
+++ b/src/redux/reducers/invitationReducer.ts
@@ -60,8 +60,8 @@ function invitationReducer(state: State = initialState, action: Action) {
         invitationAddressName,
         invitationRoadAddress,
         invitationPlaceName,
-        invitationX,
-        invitationY,
+        x,
+        y,
         images,
       } = action.payload
 
@@ -74,8 +74,8 @@ function invitationReducer(state: State = initialState, action: Action) {
           addressName: invitationAddressName,
           roadAddress: invitationRoadAddress,
           placeName: invitationPlaceName,
-          latitude: invitationX,
-          longitude: invitationY,
+          latitude: x,
+          longitude: y,
           images,
         }),
         getInvitationFetching: false,

--- a/src/redux/reducers/invitationReducer.ts
+++ b/src/redux/reducers/invitationReducer.ts
@@ -3,6 +3,7 @@ import { takeLatest } from 'redux-saga/effects'
 
 /* Internal dependencies */
 import Invitation from 'models/Invitation'
+import KakaoMap from 'models/KakaoMap'
 import * as invitationAPI from 'api/invitationAPI'
 import { AsyncActionTypes, actionCreatorWithPromise, createAsyncActionsAndSaga } from 'utils/reduxUtils'
 
@@ -71,11 +72,13 @@ function invitationReducer(state: State = initialState, action: Action) {
           title: invitationTitle,
           contents: invitationContents,
           time: new Date(invitationTime),
-          addressName: invitationAddressName,
-          roadAddress: invitationRoadAddress,
-          placeName: invitationPlaceName,
-          latitude: x,
-          longitude: y,
+          kakaoMap: new KakaoMap({
+            addressName: invitationAddressName,
+            roadAddress: invitationRoadAddress,
+            placeName: invitationPlaceName,
+            latitude: x,
+            longitude: y,
+          }),
           images,
         }),
         getInvitationFetching: false,

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,14 @@
+/* External dependencies */
+import moment from 'moment'
+import 'moment/locale/ko'
+
+export const getDate = (date: Date): string => `${date.getMonth() + 1}월 ${date.getDate()}일`
+
+export const getTime = (date: Date): any => {
+  const minute = date.getMinutes()
+
+  if (minute === 0) {
+    return moment(date).format('A h시')
+  }
+  return moment(date).format('A h시 mm분')
+}

--- a/src/utils/reduxUtils.ts
+++ b/src/utils/reduxUtils.ts
@@ -72,8 +72,8 @@ export const createAsyncActionsAndSaga = <L, S, E>(fetching: L, success: S, erro
   const asyncSaga = function* (action: ActionType<AT>) {
     yield put(asyncActions.fetching())
     try {
-      const result = yield call(request, action.payload)
-      yield put(asyncActions.success(result, action.uuid))
+      const { data } = yield call(request, action.payload)
+      yield put(asyncActions.success(data, action.uuid))
     } catch (error) {
       yield put(asyncActions.error(error, action.uuid))
     }


### PR DESCRIPTION
### # Description
초대장에서 서버를 통해 api요청후 데이터 받아 초대장 생성하는 기능 구현

### # Changes Detail
- 초대장 템플릿 렌더링완료시 서버로 데이터요청 보내고 받아서 초대장템플릿에 파싱하는 기능 구현

### # Tests
- [ ] 테스트 케이스 작성(SnapShot테스트 제외).
- [x] 로컬 테스트 (Staging server) 완료.

### # Issues
(연관된 PR 혹은 Task / asset 추가 / npm module 추가 / 특정 시점까지 merge 대기 등 )
- `moment` module 추가
- 서버로 api요청을 위해 proxy설정(`package.json`의 마지막부분에 `proxy`속성 추가)