### PR TITLE
feat: #76. 랜딩페이지 하단 멤버이름옆에 링크아이콘 추가

### DIFF
--- a/src/assets/icons/link.svg
+++ b/src/assets/icons/link.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+    <path fill="#fff" d="M17 7h-4v2h4c1.65 0 3 1.35 3 3s-1.35 3-3 3h-4v2h4c2.76 0 5-2.24 5-5s-2.24-5-5-5zm-6 8H7c-1.65 0-3-1.35-3-3s1.35-3 3-3h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-2zm-3-4h8v2H8v-2z"/>
+</svg>

--- a/src/components/Home/Home.module.scss
+++ b/src/components/Home/Home.module.scss
@@ -208,11 +208,20 @@
                 }
 
                 .footer-container-title {
-                    margin-bottom: 20px;
+                    margin-bottom: 24px;
+                }
+
+                .footer-member-wrapper {
+                    display: flex;
+                    align-items: center;
+
+                    .member-link-icon {
+                        margin-left: 8px;
+                    }
                 }
 
                 .footer-container-member + .footer-container-member {
-                    margin-top: 5px;
+                    margin-top: 12px;
                 }
             }
 

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -1,6 +1,9 @@
+/* External dependencies */
 import React from 'react'
 import classNames from 'classnames/bind'
 
+/* Internal dependencies */
+import SVGIcon, { Size } from 'elements/SVGIcon'
 import style from 'components/Home/Home.module.scss'
 import ImgLogo from 'assets/img_logo.png'
 import ImgMain from 'assets/images/homeImg/img_main.png'
@@ -95,22 +98,34 @@ function Home() {
             <p className={cx('footer-container-title')}>Android Developer</p>
             <p className={cx('footer-container-member')}>
               <a href="https://github.com/koba1mobile" target="_blank" rel="noopener noreferrer">
-                이두한
+                <div className={cx('footer-member-wrapper')}>
+                  <p>이두한</p>
+                  <SVGIcon className={cx('member-link-icon')} name="link" size={Size.Normal} />
+                </div>
               </a>
             </p>
             <p className={cx('footer-container-member')}>
               <a href="https://github.com/dlwls5201" target="_blank" rel="noopener noreferrer">
-                이진성
+                <div className={cx('footer-member-wrapper')}>
+                  <p>이진성</p>
+                  <SVGIcon className={cx('member-link-icon')} name="link" size={Size.Normal} />
+                </div>
               </a>
             </p>
             <p className={cx('footer-container-member')}>
               <a href="https://github.com/godjoy" target="_blank" rel="noopener noreferrer">
-                신초희
+                <div className={cx('footer-member-wrapper')}>
+                  <p>신초희</p>
+                  <SVGIcon className={cx('member-link-icon')} name="link" size={Size.Normal} />
+                </div>
               </a>
             </p>
             <p className={cx('footer-container-member')}>
               <a href="https://github.com/sunny0529" target="_blank" rel="noopener noreferrer">
-                유현선
+                <div className={cx('footer-member-wrapper')}>
+                  <p>유현선</p>
+                  <SVGIcon className={cx('member-link-icon')} name="link" size={Size.Normal} />
+                </div>
               </a>
             </p>
           </div>
@@ -118,12 +133,18 @@ function Home() {
             <p className={cx('footer-container-title')}>Web Developer</p>
             <p className={cx('footer-container-member')}>
               <a href="https://github.com/danivelop" target="_blank" rel="noopener noreferrer">
-                윤대용
+                <div className={cx('footer-member-wrapper')}>
+                  <p>윤대용</p>
+                  <SVGIcon className={cx('member-link-icon')} name="link" size={Size.Normal} />
+                </div>
               </a>
             </p>
             <p className={cx('footer-container-member')}>
               <a href="https://github.com/joi0104" target="_blank" rel="noopener noreferrer">
-                최진영
+                <div className={cx('footer-member-wrapper')}>
+                  <p>최진영</p>
+                  <SVGIcon className={cx('member-link-icon')} name="link" size={Size.Normal} />
+                </div>
               </a>
             </p>
           </div>
@@ -131,12 +152,18 @@ function Home() {
             <p className={cx('footer-container-title')}>Backend Developer</p>
             <p className={cx('footer-container-member')}>
               <a href="https://github.com/JaeHyeonKim19" target="_blank" rel="noopener noreferrer">
-                김재현
+                <div className={cx('footer-member-wrapper')}>
+                  <p>김재현</p>
+                  <SVGIcon className={cx('member-link-icon')} name="link" size={Size.Normal} />
+                </div>
               </a>
             </p>
             <p className={cx('footer-container-member')}>
               <a href="https://github.com/kwonsye" target="_blank" rel="noopener noreferrer">
-                권수연
+                <div className={cx('footer-member-wrapper')}>
+                  <p>권수연</p>
+                  <SVGIcon className={cx('member-link-icon')} name="link" size={Size.Normal} />
+                </div>
               </a>
             </p>
           </div>
@@ -144,12 +171,18 @@ function Home() {
             <p className={cx('footer-container-title')}>UX/UI designer</p>
             <p className={cx('footer-container-member')}>
               <a href="https://flygoeun.tistory.com" target="_blank" rel="noopener noreferrer">
-                고은이
+                <div className={cx('footer-member-wrapper')}>
+                  <p>고은이</p>
+                  <SVGIcon className={cx('member-link-icon')} name="link" size={Size.Normal} />
+                </div>
               </a>
             </p>
             <p className={cx('footer-container-member')}>
               <a href="https://uxdlab.tistory.com" target="_blank" rel="noopener noreferrer">
-                전다영
+                <div className={cx('footer-member-wrapper')}>
+                  <p>전다영</p>
+                  <SVGIcon className={cx('member-link-icon')} name="link" size={Size.Normal} />
+                </div>
               </a>
             </p>
           </div>

--- a/src/elements/SVGIcon/SVGIcon.tsx
+++ b/src/elements/SVGIcon/SVGIcon.tsx
@@ -14,11 +14,12 @@ export enum Size {
 }
 
 interface SVGIconProps {
+  className?: string
   name: string
   size?: Size
 }
 
-function SVGIcon({ name, size = Size.Normal }: SVGIconProps) {
+function SVGIcon({ className, name, size = Size.Normal }: SVGIconProps) {
   const src = useMemo(() => {
     const fileName = _.endsWith(name, '.svg') ? name : `${name}.svg`
     try {
@@ -29,7 +30,7 @@ function SVGIcon({ name, size = Size.Normal }: SVGIconProps) {
   }, [name])
 
   return (
-    <Styled.SVGIconWrapper size={size}>
+    <Styled.SVGIconWrapper className={className} size={size}>
       <Styled.SVGIcon src={src} />
     </Styled.SVGIconWrapper>
   )

--- a/src/elements/SVGIcon/index.ts
+++ b/src/elements/SVGIcon/index.ts
@@ -1,1 +1,1 @@
-export { default } from './SVGIcon'
+export { default, Size } from './SVGIcon'


### PR DESCRIPTION
### # 변경사항
랜딩페이지 하단에 멤버이름옆에 링크 아이콘 추가

변경전
![before](https://user-images.githubusercontent.com/55433950/92327652-18cbee00-f096-11ea-9320-a7b0f49c14dd.PNG)

변경후
![after](https://user-images.githubusercontent.com/55433950/92327657-21242900-f096-11ea-93a5-2f1b5eb069b6.PNG)


### # 변경 세부사항
- 아이콘추가

### # 테스트
- [ ] 테스트 케이스 작성(SnapShot테스트 제외).
- [x] 로컬 테스트 (Staging server) 완료.

### # 이슈
(연관된 PR 혹은 Task / asset 추가 / npm module 추가 / 특정 시점까지 merge 대기 등 )
- resolve #76 
