### PR TITLE
fix: #109. 타임존 서울로 변경하여 시간 다르게 뜨던 버그 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "lru-cache": "6.0.0",
     "mini-css-extract-plugin": "0.9.0",
     "moment": "2.27.0",
+    "moment-timezone": "0.5.31",
     "node-plop": "0.25.0",
     "node-sass": "4.14.1",
     "optimize-css-assets-webpack-plugin": "5.0.3",

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,24 +1,20 @@
 /* External dependencies */
 import moment from 'moment'
 import 'moment/locale/ko'
+import 'moment-timezone'
+
+moment.tz.setDefault('Asia/Seoul')
 
 export const getDate = (date: Date): string => {
-  if (typeof date === 'string') {
-    date = new Date(date)
-  }
-
-  return `${date.getMonth() + 1}월 ${date.getDate()}일`
+  return moment(date).format('M월 D일')
 }
 
 export const getTime = (date: Date): any => {
-  if (typeof date === 'string') {
-    date = new Date(date)
+  const newDate = moment(date)
+
+  if (newDate.minute() === 0) {
+    return newDate.format('A h시')
   }
 
-  const minute = date.getMinutes()
-
-  if (minute === 0) {
-    return moment(date).format('A h시')
-  }
-  return moment(date).format('A h시 mm분')
+  return newDate.format('A h시 mm분')
 }


### PR DESCRIPTION
### # 변경사항
aws서버가 다른 나라에 있음에 따라 초대장의 시간 타임존이 서울이 아니어서 시간이 9시간 느리게 뜨던 문제가 있었음
moment의 timezone설정을 하여 서울로 변경

### # 변경 세부사항
- moment-timezone을 서울로 변경

### # 테스트
- [ ] 테스트 케이스 작성(SnapShot테스트 제외).
- [x] 로컬 테스트 (Staging server) 완료.

### # 이슈
(연관된 PR 혹은 Task / asset 추가 / npm module 추가 / 특정 시점까지 merge 대기 등 )
- fix #109 
