### PR TITLE
feat: #111. 지도에서 스크롤막기

### DIFF
--- a/src/elements/Map/Map.tsx
+++ b/src/elements/Map/Map.tsx
@@ -22,6 +22,10 @@ function Map({ map, placeName }: MapProps) {
     setIsWideMap(prev => !prev)
   }, [])
 
+  const handleScrollMap = useCallback(e => {
+    e.stopPropagation()
+  }, [])
+
   useEffect(() => {
     mapService.current = new KakaoMapService(mapContainer.current, map.latitude, map.longitude)
     mapService.current.loadMap()
@@ -45,7 +49,7 @@ function Map({ map, placeName }: MapProps) {
           {map.roadAddress}
         </Styled.RoadAddress>
       </Styled.AddressWrapper>
-      <Styled.MapContainer ref={mapContainer} isWideMap={isWideMap} />
+      <Styled.MapContainer ref={mapContainer} isWideMap={isWideMap} onWheel={handleScrollMap} />
       <Styled.MapSizeIconWrapper onClick={handleClickMapSize}>
         <Styled.MapSizeIcon name={isWideMap ? 'squares-filled' : 'squares'} size={Size.Small} />
       </Styled.MapSizeIconWrapper>


### PR DESCRIPTION
### # 변경사항
모바일에서 지도 움직일때 초대장 전체가 스크롤 되는것 막음

### # 변경 세부사항
- map container에 wheel이벤트로 이벤트 버블릭 막음

### # 테스트
- [ ] 테스트 케이스 작성(SnapShot테스트 제외).
- [x] 로컬 테스트 (Staging server) 완료.

### # 이슈
(연관된 PR 혹은 Task / asset 추가 / npm module 추가 / 특정 시점까지 merge 대기 등 )
- resolve #111 
